### PR TITLE
feat: sqlite persistence support

### DIFF
--- a/api-platform/config/packages/api_platform.yaml
+++ b/api-platform/config/packages/api_platform.yaml
@@ -1,9 +1,10 @@
 api_platform:
-#  formats:
-#    jsonld: [ 'application/ld+json' ]
+  formats:
+    jsonld: [ 'application/ld+json' ]
+    json: ['application/json']
 
-  # mapping:
-  #   paths:
-  #     - '%kernel.project_dir%/src'
+#  mapping:
+#    paths:
+#      - '%kernel.project_dir%/src'
   doctrine:
     enabled: true

--- a/api-platform/config/packages/doctrine.yaml
+++ b/api-platform/config/packages/doctrine.yaml
@@ -1,6 +1,6 @@
 doctrine:
   dbal:
-    url: 'sqlite:///%kernel.project_dir%/var/data.db'
+    url: '%database_url%'
 
     # IMPORTANT: You MUST configure your server version,
     # either here or in the DATABASE_URL env var (see .env file)
@@ -9,12 +9,12 @@ doctrine:
     auto_generate_proxy_classes: true
     naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
-    # mappings:
-    #   App:
-    #     is_bundle: false
-    #     dir: '/src/api-platform/src/Entity'
-    #     prefix: 'App\Entity'
-    #     alias: App
+    mappings:
+      App:
+        is_bundle: false
+        dir: '%kernel.project_dir%/src'
+        prefix: 'App\ApiResource'
+        alias: App
 
 when@test:
   doctrine:

--- a/api-platform/config/packages/doctrine_migrations.yaml
+++ b/api-platform/config/packages/doctrine_migrations.yaml
@@ -2,5 +2,5 @@ doctrine_migrations:
   migrations_paths:
     # namespace is arbitrary but should be different from App\Migrations
     # as migrations classes should NOT be autoloaded
-    'DoctrineMigrations': '%kernel.project_dir%/migrations'
+    'DoctrineMigrations': '/src/api-platform/src'
   enable_profiler: false

--- a/api-platform/config/services.yaml
+++ b/api-platform/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    database_url: 'sqlite:///%kernel.project_dir%/var/data.db'
 
 services:
     # default configuration for services in *this* file

--- a/api-platform/src/Kernel.php
+++ b/api-platform/src/Kernel.php
@@ -4,9 +4,19 @@ namespace App;
 
 use ApiPlatform\Metadata\ApiResource;
 use App\Metadata\Resource\Factory\StaticResourceNameCollectionFactory;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
+use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\Version\Direction;
+use Doctrine\Migrations\Version\Version;
+use Doctrine\ORM\EntityManagerInterface;
+use DoctrineMigrations\Migration;
 use ReflectionClass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,6 +64,11 @@ class Kernel extends BaseKernel
 
         $services->set(StaticResourceNameCollectionFactory::class)->args(['$classes' => $resources]);
 
+        $container->parameters()->set(
+            'database_url',
+            sprintf('sqlite:///%s/%s', $this->getDBDir(), 'data.db')
+        );
+
         if (function_exists('App\DependencyInjection\configure')) {
             configure($container);
         }
@@ -74,6 +89,62 @@ class Kernel extends BaseKernel
     public function getCacheDir(): string
     {
         return parent::getCacheDir() . $this->guide;
+    }
+
+    public function getDBDir(): string
+    {
+        return $this->getProjectDir() . '/var/databases/' . $this->guide;
+    }
+
+    public function executeMigration(string $direction = Direction::UP): void
+    {
+        if (!class_exists(\DoctrineMigrations\Migration::class)) {
+            return;
+        }
+        $this->boot();
+        @mkdir('var/databases/' . $this->guide, recursive: true);
+        $this->createMetadataStorageTable();
+
+        $conf = new Configuration();
+        $conf->addMigrationClass(Migration::class);
+        $conf->setTransactional(true);
+        $conf->setCheckDatabasePlatform(true);
+        $meta = new TableMetadataStorageConfiguration();
+        $meta->setTableName('doctrine_migration_versions');
+        $conf->setMetadataStorageConfiguration($meta);
+
+        $confLoader = new ExistingConfiguration($conf);
+        /** @var EntityManagerInterface $em */
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $loader = new ExistingEntityManager($em);
+        $dependencyFactory = DependencyFactory::fromEntityManager($confLoader, $loader);
+
+        $planCalculator = $dependencyFactory->getMigrationPlanCalculator();
+        $plan = $planCalculator->getPlanForVersions([new Version(Migration::class)], $direction);
+        $migrator = $dependencyFactory->getMigrator();
+        $migratorConfigurationFactory = $dependencyFactory->getConsoleInputMigratorConfigurationFactory();
+        $migratorConfiguration = $migratorConfigurationFactory->getMigratorConfiguration(new ArrayInput([]));
+
+        $migrator->migrate($plan, $migratorConfiguration);
+    }
+
+    private function createMetadataStorageTable(): void
+    {
+        /** @var EntityManagerInterface $em */
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $connection = $em->getConnection();
+
+        $tables = $connection->createSchemaManager()->listTableNames();
+
+        if (in_array('doctrine_migration_versions', $tables, true)) {
+            return;
+        }
+
+        $createTable = 'CREATE TABLE doctrine_migration_versions(version VARCHAR(191) PRIMARY KEY NOT NULL, executed_at DATETIME DEFAULT NULL, execution_time INT DEFAULT NULL)';
+        $connection->executeStatement($createTable);
+        $createIndex = 'CREATE UNIQUE INDEX `primary` ON doctrine_migration_versions(version)';
+        $connection->executeStatement($createIndex);
+
     }
 }
 

--- a/api-platform/src/use-doctrine.php
+++ b/api-platform/src/use-doctrine.php
@@ -1,0 +1,86 @@
+<?php
+
+// Should be a real guide
+
+namespace App\ApiResource {
+
+    use ApiPlatform\Metadata\ApiResource;
+    use Doctrine\ORM\Mapping as ORM;
+
+    /**
+     * Book.
+     *
+     * @author Antoine Bluchet <soyuka@gmail.com>
+     */
+    #[ApiResource]
+    #[ORM\Entity]
+    class Book
+    {
+        #[ORM\Column(type: 'integer')]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'AUTO')]
+        private $id;
+        #[ORM\Column]
+        public $name;
+        #[ORM\Column(unique: true)]
+        public $isbn;
+
+        public function getId()
+        {
+            return $this->id;
+        }
+    }
+}
+
+namespace App\Playground {
+
+    use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+    use App\ApiResource\Book;
+    use App\Kernel;
+    use Symfony\Component\HttpFoundation\Request;
+    use Symfony\Component\HttpKernel\KernelInterface;
+
+    function request(): Request
+    {
+        $body = [
+            'name' => 'bookToto',
+            'isbn' => 'abcd'
+        ];
+        return Request::create('/books.jsonld', 'POST',[], [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($body));
+    }
+
+    function setup(Kernel $kernel): void
+    {
+        $kernel->executeMigration();
+    }
+}
+
+namespace DoctrineMigrations {
+
+    use Doctrine\DBAL\Schema\Schema;
+    use Doctrine\Migrations\AbstractMigration;
+
+    /**
+     * Auto-generated Migration: Please modify to your needs!
+     */
+    final class Migration extends AbstractMigration
+    {
+        public function getDescription(): string
+        {
+            return '';
+        }
+
+        public function up(Schema $schema): void
+        {
+            // this up() migration is auto-generated, please modify it to your needs
+            $this->addSql('CREATE TABLE book (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL, isbn VARCHAR(255) NOT NULL)');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_CBE5A331CC1CF4E6 ON book (isbn)');
+        }
+
+        public function down(Schema $schema): void
+        {
+            // this down() migration is auto-generated, please modify it to your needs
+            $this->addSql('DROP TABLE book');
+        }
+    }
+}

--- a/src/php/index.php
+++ b/src/php/index.php
@@ -1,7 +1,5 @@
 <?php
 
-use Symfony\Component\HttpFoundation\Request;
-
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -26,5 +24,7 @@ function run(string $guide) {
         ->resolve();
 
     $app = $app(...$args);
+
+    $app->executeMigration();
     $app->request();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no 
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Hook persistence support via sqlite: 
- automatic database creation for each guide if needed
- metadata table creation (doctrine_migration_versions), needed for further migrations
- If migrations are defined in a guide (will need to respect the `DoctrineMigrations` namespace and `Migration` class name), they are played/ made available in the Kernel 
